### PR TITLE
remove columns "UserSchemaName", "UserTableName" from GlobalStateTable 

### DIFF
--- a/src/TriggersBinding/MySqlTriggerConstants.cs
+++ b/src/TriggersBinding/MySqlTriggerConstants.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MySql
         public const string GlobalStateTableName = SchemaName + "." + GlobalState;
         public const string GlobalStateTableUserFunctionIDColumnName = "UserFunctionID";
         public const string GlobalStateTableUserTableIDColumnName = "UserTableID";
-        public const string GlobalStateTableUserSchemaName = "UserSchemaName";
-        public const string GlobalStateTableUserTableName = "UserTableName";
         public const string GlobalStateTableLastPolledTimeColumnName = "LastPolledTime";
 
         public const string SysChangeVersionColumnName = "SYS_CHANGE_VERSION";

--- a/src/TriggersBinding/MySqlTriggerListener.cs
+++ b/src/TriggersBinding/MySqlTriggerListener.cs
@@ -285,8 +285,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.MySql
                     CREATE TABLE IF NOT EXISTS {GlobalStateTableName} (
                         {GlobalStateTableUserFunctionIDColumnName} char(16) NOT NULL,
                         {GlobalStateTableUserTableIDColumnName} char(64) NOT NULL,
-                        {GlobalStateTableUserSchemaName} char(64) NOT NULL,
-                        {GlobalStateTableUserTableName} char(64) NOT NULL,
                         {GlobalStateTableLastPolledTimeColumnName} Datetime NOT NULL DEFAULT {MYSQL_FUNC_CURRENTTIME},
                         PRIMARY KEY ({GlobalStateTableUserFunctionIDColumnName}, {GlobalStateTableUserTableIDColumnName})
                     );
@@ -318,8 +316,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.MySql
         /// <returns>The time taken in ms to execute the command</returns>
         private async Task<long> InsertGlobalStateTableRowAsync(MySqlConnection connection, MySqlTransaction transaction, string userTableId, CancellationToken cancellationToken)
         {
-            string insertRowGlobalStateTableQuery = $"INSERT IGNORE INTO {GlobalStateTableName} ({GlobalStateTableUserFunctionIDColumnName}, {GlobalStateTableUserTableIDColumnName}, {GlobalStateTableUserSchemaName}, {GlobalStateTableUserTableName})" +
-                $" VALUES ('{this._userFunctionId}', '{userTableId}', {this._userTable.SingleQuotedSchema}, {this._userTable.SingleQuotedName});";
+            string insertRowGlobalStateTableQuery = $"INSERT IGNORE INTO {GlobalStateTableName} ({GlobalStateTableUserFunctionIDColumnName}, {GlobalStateTableUserTableIDColumnName})" +
+                $" VALUES ('{this._userFunctionId}', '{userTableId}');";
 
             using (var insertRowGlobalStateTableCommand = new MySqlCommand(insertRowGlobalStateTableQuery, connection, transaction))
             {


### PR DESCRIPTION
"UserSchemaName", "UserTableName" columns not required for process, it was just added in previous pr to assume that user can easily track the respective lease table by using their schema and table name. But, it's not required as we already give table id and function id in logs now.